### PR TITLE
nvidia: nvgpu: Fix nvidia/nvgpu path in Makefile

### DIFF
--- a/nvidia/nvgpu/drivers/gpu/nvgpu/Makefile.nvgpu
+++ b/nvidia/nvgpu/drivers/gpu/nvgpu/Makefile.nvgpu
@@ -6,7 +6,7 @@ ccflags-y += -Idrivers/devfreq
 ccflags-y += -I$(srctree)/nvidia/nvgpu/include
 ccflags-y += -I$(srctree)/nvidia/nvgpu/include/uapi
 ccflags-y += -I$(srctree)/nvidia/nvgpu/drivers/gpu/nvgpu/include
-ccflags-y += -I$(srctree)/nvgpu/drivers/gpu/nvgpu
+ccflags-y += -I$(srctree)/nvidia/nvgpu/drivers/gpu/nvgpu
 ccflags-y += -Wno-multichar
 ccflags-y += -Werror
 ccflags-y += -Wno-error=cpp


### PR DESCRIPTION
Fixes the error:
```
drivers/gpu/../../nvidia/nvgpu/drivers/gpu/nvgpu/common/linux/kmem.c:30:25: fatal error: gk20a/gk20a.h: No such file or directory
 #include "gk20a/gk20a.h"
```

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>